### PR TITLE
Update Umami script URL to v2 version

### DIFF
--- a/application.py
+++ b/application.py
@@ -35,7 +35,7 @@ app.index_string = f"""
     <head>
         <script async defer 
             data-website-id="267edbf9-6b86-4b7c-af87-553be3218af5"
-            src="https://umami.snap.uaf.edu/umami.js"
+            src="https://umami.snap.uaf.edu/script.js"
             data-domains="snap.uaf.edu"
             data-do-not-track="true"
         ></script>


### PR DESCRIPTION
This PR updates the Umami script URL to work with Umami v2. I.e., `umami.js` was changed to `script.js`.

You will need the Umami v2 Vagrant VM to test against. If you do not already have this set up, refer to the Vagrant instructions in https://github.com/ua-snap/nccwsc-projects/pull/154.

With the Vagrant VM running, and assuming Umami's port is forwarded to port 9999 of the host, simply change the Umami config in `application.py` to:

```
<script async defer 
    data-website-id="267edbf9-6b86-4b7c-af87-553be3218af5"
    src="http://localhost:9999/script.js"
    data-do-not-track="true"
></script>
```

Note that the `data-domains` attribute has been removed in the code above, for testing.

Then run this webapp locally and verify that your traffic shows up here: http://localhost:9999/websites/267edbf9-6b86-4b7c-af87-553be3218af5